### PR TITLE
Hide tracks in StreamingAssets in editor select track panel.

### DIFF
--- a/TECHMANIA/Assets/Scripts/Components/Main Menu/SelectTrackPanel.cs
+++ b/TECHMANIA/Assets/Scripts/Components/Main Menu/SelectTrackPanel.cs
@@ -137,6 +137,8 @@ public class SelectTrackPanel : MonoBehaviour
     {
         refreshing = true;
 
+        // If player is inside streaming assets track folder in select track panel,
+        // move them out to track root folder when they enter editor selct track panel.
         if (ShowNewTrackCard() && currentLocation.Contains(Paths.GetStreamingTrackRootFolder()))
         {
             currentLocation = "";

--- a/TECHMANIA/Assets/Scripts/Components/Main Menu/SelectTrackPanel.cs
+++ b/TECHMANIA/Assets/Scripts/Components/Main Menu/SelectTrackPanel.cs
@@ -137,6 +137,12 @@ public class SelectTrackPanel : MonoBehaviour
     {
         refreshing = true;
 
+        if (ShowNewTrackCard() && currentLocation.Contains(Paths.GetStreamingTrackRootFolder()))
+        {
+            currentLocation = "";
+            selectedCardIndex = -1;
+        }
+
         // Initialization and/or disaster recovery.
         if (currentLocation == "" ||
             !Directory.Exists(currentLocation))
@@ -227,6 +233,9 @@ public class SelectTrackPanel : MonoBehaviour
         {
             foreach (Subfolder s in subfolderList[currentLocation])
             {
+                if (ShowNewTrackCard() &&
+                    s.path.Contains(Paths.GetStreamingTrackRootFolder())
+                ) continue;
                 subfolders.Add(s);
             }
             subfolders.Sort((Subfolder s1, Subfolder s2) =>

--- a/TECHMANIA/Assets/Scripts/Paths.cs
+++ b/TECHMANIA/Assets/Scripts/Paths.cs
@@ -279,7 +279,7 @@ public static class Paths
 
     public static string HidePlatformInternalPath(string fullPath)
     {
-#if UNITY_IOS
+#if UNITY_ANDROID || UNITY_IOS
         return fullPath
             .Replace(Paths.GetStreamingTrackRootFolder(), "Tracks")
             .Replace(Paths.GetTrackRootFolder(), "Tracks")


### PR DESCRIPTION
StreamingAssets are read only.  
This pr also hide Android platform path because it's `jar:file://`