### PR TITLE
Fix ios runtime error

### DIFF
--- a/TECHMANIA/Assets/Scripts/Serializable/Options.cs
+++ b/TECHMANIA/Assets/Scripts/Serializable/Options.cs
@@ -442,6 +442,11 @@ public class Options : OptionsBase
 
     private void PreparePerTrackOptionsToSerialize()
     {
+        if (inMemoryPerTrackOptions == null)
+        {
+            inMemoryPerTrackOptions = new Dictionary<string, PerTrackOptions>();
+        }
+
         perTrackOptions = new Dictionary<string, PerTrackOptions>();
         foreach (KeyValuePair<string, PerTrackOptions> pair in
             inMemoryPerTrackOptions)


### PR DESCRIPTION
NullReferenceException: Object reference not set to an instance of an object.